### PR TITLE
Publish the site every day

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,10 @@ name: Publish to GitHub Pages
 on:
   push:
     branches: [future]
+  schedule:
+    # Publish every day, so can be sure that all updates to the modules
+    # will be published, even if I don't take care of this taskgit
+    - cron: "0 4 * * *"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 concurrency:


### PR DESCRIPTION
The site will be build now every day and published to GitHub pages.

This should ensure, that the site will contain all changes done to each and every submodule, even if I don't take care of this task.